### PR TITLE
Remove the links around figures in the JOSS paper

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -73,7 +73,7 @@ plt.show()
 ```
 
 
-[![Fig. 1: Local Spatial Autocorrelation](figs/local_autocorrelation.png)](https://github.com/pysal/splot/blob/master/notebooks/esda_morans_viz.ipynb)*Fig. 1: Local spatial autocorrelation*
+![Local spatial autocorrelation (see https://github.com/pysal/splot/blob/master/notebooks/esda_morans_viz.ipynb).](figs/local_autocorrelation.png)
 
 The user can now further visually assess whether there is dependency between high crime rates (fig. 2, rgb variable) and high income in this neighborhood (fig. 2, alpha variable). Darker shades of the colormap correspond to higher crime and income values, displayed through a static Value-by-Alpha Choropleth using `splot.mapping.vba_choropleth`.
 
@@ -90,7 +90,7 @@ plt.show()
 ```
 
 
-[![Fig. 2: Value-by-alpha mapping](figs/vba_choropleth.png)](https://github.com/pysal/splot/blob/master/notebooks/mapping_vba.ipynb)*Fig. 2: Value-by-alpha mapping*
+![Value-by-alpha mapping (see https://github.com/pysal/splot/blob/master/notebooks/mapping_vba.ipynb).](figs/vba_choropleth.png)
 
 Ultimately, the `splot` package is designed to facilitate the creation of both static plots ready for publication, and interactive visualizations for quick iteration and spatial data exploration. Although most of `splot` is currently implemented with a `matplotlib` backend, `splot` is framework independent. In that sense, `splot` offers a "grammar" of views that are important and useful in spatial analyses and geographic data science. The `splot` package is not restricted or limited to the current `matplotlib` implementation and can be advanced by integrating emerging or succeeding interactive visualization toolkits, such as `altair` or `bokeh`.
 


### PR DESCRIPTION
Include the links in the figure caption instead to avoid issues when compiling the paper PDF.

You can preview the compiled paper at: http://res.cloudinary.com/hju22ue2k/image/upload/v1580414535/wvsuqwnyi5rgshtoru7i.pdf

The "Figure 1" etc are added automatically when compiling the paper. I used the link to the master branch notebook but this is probably not ideal since that link will break if the notebooks are moved. It would be best to link to the specific version used in the JOSS paper (feel free to update this branch).

openjournals/joss-reviews#1882

1. [ ] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [ ] This pull request is directed to the `pysal/dev` branch.
3. [ ] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [ ] The justification for this PR is: 
